### PR TITLE
Refactor ProjectID handling

### DIFF
--- a/Sources/Core/Authenticator.swift
+++ b/Sources/Core/Authenticator.swift
@@ -54,9 +54,11 @@ class Authenticator {
         }
 
         // scenario 2: we have to register the app instance
-        let endpoint = Endpoints.AppUser.post(
-            configuration: configuration
+        var endpoint = Endpoints.AppUser.post(
+            appId: configuration.appId,
+            appSecret: configuration.appSecret
         )
+        endpoint.domain = configuration.domain
         let publisher = urlSession.dataTaskPublisher(for: endpoint)
             .handleEvents(receiveOutput: { [weak self] response in
                 self?.token = response.token
@@ -98,11 +100,14 @@ class Authenticator {
 
             let publisher = self.validateAppUser(withConfiguration: configuration)
                 .map { appUser -> Endpoint<Token> in
-                    return Endpoints.Token.get(
-                        configuration: configuration,
+                    var endpoint = Endpoints.Token.get(
+                        appId: configuration.appId,
+                        appSecret: configuration.appSecret,
                         appUser: appUser,
                         projectId: projectId
                     )
+                    endpoint.domain = configuration.domain
+                    return endpoint
                 }
                 .tryMap { tokenEndpoint -> (URLSession, Endpoint<Token>) in
                     return (self.urlSession, tokenEndpoint)

--- a/Sources/Core/Authenticator.swift
+++ b/Sources/Core/Authenticator.swift
@@ -9,24 +9,24 @@ import Foundation
 import Dispatch
 import Combine
 
-public protocol AuthenticatorDelegate: AnyObject {
+protocol AuthenticatorDelegate: AnyObject {
     func authenticator(_ authenticator: Authenticator, appUserForConfiguration configuration: Configuration) -> AppUser?
     func authenticator(_ authenticator: Authenticator, appUserUpdated appUser: AppUser)
 
-    func authenticator(_ authenticator: Authenticator, projectIdForConfiguration configuration: Configuration) -> String
+    func authenticator(_ authenticator: Authenticator, projectIdForConfiguration configuration: Configuration) -> String?
 }
 
-public class Authenticator {
+class Authenticator {
     public let urlSession: URLSession
 
-    public weak var delegate: AuthenticatorDelegate?
+    weak var delegate: AuthenticatorDelegate?
 
     enum Error: Swift.Error {
         case missingAuthenticator
         case missingProject
     }
 
-    public private(set) var token: Token?
+    private(set) var token: Token?
 
     private let queue: DispatchQueue = .init(label: "io.snabble.network.authenticator.\(UUID().uuidString)")
 

--- a/Sources/Core/Endpoint.swift
+++ b/Sources/Core/Endpoint.swift
@@ -27,23 +27,19 @@ public enum Endpoints {
 public struct Endpoint<Response> {
     public let method: HTTPMethod
     public let path: String
-    public let configuration: Configuration
 
     public let parse: (Data) throws -> Response
 
     var token: Token?
     var headerFields: [String: String] = [:]
 
-    public init(path: String, method: HTTPMethod, configuration: Configuration, parse: @escaping (Data) throws -> Response) {
+    public init(path: String, method: HTTPMethod, parse: @escaping (Data) throws -> Response) {
         self.path = path
         self.method = method
-        self.configuration = configuration
         self.parse = parse
     }
 
-    var domain: Domain {
-        configuration.domain
-    }
+    var domain: Domain = .production
 
     enum Error: Swift.Error {
         case invalidRequestError(String)

--- a/Sources/Core/Endpoints/AppUserEndpoint.swift
+++ b/Sources/Core/Endpoints/AppUserEndpoint.swift
@@ -10,28 +10,27 @@ import SwiftOTP
 
 extension Endpoints {
     enum AppUser {
-        static func post(configuration: Configuration, projectId: String? = nil) -> Endpoint<UsersResponse> {
+        static func post(appId: String, appSecret: String, projectId: String? = nil) -> Endpoint<UsersResponse> {
             var queryItems: [URLQueryItem]?
             if let projectId = projectId {
                 queryItems = [.init(name: "project", value: projectId)]
             }
             var endpoint: Endpoint<UsersResponse> = .init(
-                path: "/apps/\(configuration.appId)/users",
+                path: "/apps/\(appId)/users",
                 method: .post(nil, queryItems),
-                configuration: configuration,
                 parse: { data in
                     try Endpoints.jsonDecoder.decode(UsersResponse.self, from: data)
                 }
             )
-            if let authorization = authorization(withConfiguration: configuration) {
+            if let authorization = authorization(appId: appId, appSecret: appSecret) {
                 endpoint.headerFields = ["Authorization": "Basic \(authorization)"]
             }
             return endpoint
         }
 
-        private static func authorization(withConfiguration configuration: Configuration) -> String? {
-            guard let password = password(withSecret: configuration.appSecret, forDate: Date()) else { return nil }
-            return "\(configuration.appId):\(password)".data(using: .utf8)?.base64EncodedString()
+        private static func authorization(appId: String, appSecret: String) -> String? {
+            guard let password = password(withSecret: appSecret, forDate: Date()) else { return nil }
+            return "\(appId):\(password)".data(using: .utf8)?.base64EncodedString()
         }
 
         private static func password(withSecret secret: String, forDate date: Date) -> String? {

--- a/Sources/Core/Endpoints/PhoneEndpoint.swift
+++ b/Sources/Core/Endpoints/PhoneEndpoint.swift
@@ -9,31 +9,29 @@ import Foundation
 
 extension Endpoints {
     public enum Phone {
-        public static func auth(configuration: Configuration, phoneNumber: String) -> Endpoint<Void> {
+        public static func auth(appId: String, phoneNumber: String) -> Endpoint<Void> {
             // swiftlint:disable:next force_try
             let data = try! JSONSerialization.data(withJSONObject: [
                 "phoneNumber": phoneNumber
             ])
             return .init(
-                path: "/\(configuration.appId)/verification/sms",
+                path: "/\(appId)/verification/sms",
                 method: .post(data, nil),
-                configuration: configuration,
                 parse: { _ in
                     return ()
                 }
             )
         }
 
-        public static func login(configuration: Configuration, phoneNumber: String, OTP: String) -> Endpoint<SnabbleNetwork.AppUser?> {
+        public static func login(appId: String, phoneNumber: String, OTP: String) -> Endpoint<SnabbleNetwork.AppUser?> {
             // swiftlint:disable:next force_try
             let data = try! JSONSerialization.data(withJSONObject: [
                 "otp": OTP,
                 "phoneNumber": phoneNumber
             ])
             return .init(
-                path: "/\(configuration.appId)/verification/sms/otp",
+                path: "/\(appId)/verification/sms/otp",
                 method: .post(data, nil),
-                configuration: configuration,
                 parse: { data in
                     do {
                         return try Endpoints.jsonDecoder.decode(SnabbleNetwork.AppUser.self, from: data)
@@ -51,15 +49,14 @@ extension Endpoints {
                 })
         }
 
-        public static func delete(configuration: Configuration, phoneNumber: String) -> Endpoint<Void> {
+        public static func delete(appId: String, phoneNumber: String) -> Endpoint<Void> {
             // swiftlint:disable:next force_try
             let data = try! JSONSerialization.data(withJSONObject: [
                 "phoneNumber": phoneNumber
             ])
             return .init(
-                path: "/\(configuration.appId)/verification/sms/delete",
+                path: "/\(appId)/verification/sms/delete",
                 method: .post(data, nil),
-                configuration: configuration,
                 parse: { _ in
                     return ()
                 }

--- a/Sources/Core/Endpoints/TokenEndpoint.swift
+++ b/Sources/Core/Endpoints/TokenEndpoint.swift
@@ -11,7 +11,8 @@ import SwiftOTP
 extension Endpoints {
     enum Token {
         static func get(
-            configuration: Configuration,
+            appId: String,
+            appSecret: String,
             appUser: SnabbleNetwork.AppUser,
             projectId: String,
             role: SnabbleNetwork.Token.Scope = .retailerApp
@@ -22,19 +23,18 @@ extension Endpoints {
                                                                     .init(name: "project", value: projectId),
                                                                     .init(name: "role", value: role.rawValue)
                                                                  ]),
-                                                                 configuration: configuration,
                                                                  parse: { data in
                 try Endpoints.jsonDecoder.decode(SnabbleNetwork.Token.self, from: data)
             })
-            if let authorization = authorization(withConfiguration: configuration, appUser: appUser) {
+            if let authorization = authorization(appId: appId, appSecret: appSecret, appUser: appUser) {
                 endpoint.headerFields = ["Authorization": "Basic \(authorization)"]
             }
             return endpoint
         }
 
-        private static func authorization(withConfiguration configuration: Configuration, appUser: SnabbleNetwork.AppUser) -> String? {
-            guard let password = password(withSecret: configuration.appSecret, forDate: Date()) else { return nil }
-            return "\(configuration.appId):\(password):\(appUser.id):\(appUser.secret)".data(using: .utf8)?.base64EncodedString()
+        private static func authorization(appId: String, appSecret: String, appUser: SnabbleNetwork.AppUser) -> String? {
+            guard let password = password(withSecret: appSecret, forDate: Date()) else { return nil }
+            return "\(appId):\(password):\(appUser.id):\(appUser.secret)".data(using: .utf8)?.base64EncodedString()
         }
 
         private static func password(withSecret secret: String, forDate date: Date) -> String? {

--- a/Sources/Core/Endpoints/UserEndpoint.swift
+++ b/Sources/Core/Endpoints/UserEndpoint.swift
@@ -9,33 +9,30 @@ import Foundation
 
 extension Endpoints {
     public enum User {
-        public static func me(configuration: Configuration) -> Endpoint<SnabbleNetwork.User> {
+        public static func me() -> Endpoint<SnabbleNetwork.User> {
             return .init(
                 path: "/apps/users/me",
                 method: .get(nil),
-                configuration: configuration,
                 parse: { data in
                     try Endpoints.jsonDecoder.decode(SnabbleNetwork.User.self, from: data)
                 }
             )
         }
         
-        public static func update(configuration: Configuration, details: SnabbleNetwork.User.Details) -> Endpoint<Void> {
+        public static func update(details: SnabbleNetwork.User.Details) -> Endpoint<Void> {
             return .init(
                 path: "/apps/users/me/details",
                 method: .put(try? Endpoints.jsonEncoder.encode(details)),
-                configuration: configuration,
                 parse: { _ in
                     return ()
                 }
             )
         }
         
-        public static func erase(configuration: Configuration) -> Endpoint<Void> {
+        public static func erase() -> Endpoint<Void> {
             return .init(
                 path: "/apps/users/me/erase",
                 method: .post(nil, nil),
-                configuration: configuration,
                 parse: { _ in
                     return ()
                 }

--- a/Sources/Core/Models/Configuration.swift
+++ b/Sources/Core/Models/Configuration.swift
@@ -11,13 +11,11 @@ public struct Configuration {
     public let appId: String
     public let appSecret: String
     public let domain: Domain
-    public let projectId: String
 
-    public init(appId: String, appSecret: String, domain: Domain, projectId: String) {
+    public init(appId: String, appSecret: String, domain: Domain) {
         self.appId = appId
         self.appSecret = appSecret
         self.domain = domain
-        self.projectId = projectId
     }
 }
 

--- a/Sources/Core/NetworkManager.swift
+++ b/Sources/Core/NetworkManager.swift
@@ -16,10 +16,12 @@ public protocol NetworkManagerDelegate: AnyObject {
 }
 
 public class NetworkManager {
+    public let configuration: Configuration
     private let authenticator: Authenticator
     public weak var delegate: NetworkManagerDelegate?
 
-    public init(urlSession: URLSession = .shared) {
+    public init(configuration: Configuration, urlSession: URLSession = .shared) {
+        self.configuration = configuration
         self.authenticator = Authenticator(urlSession: urlSession)
         self.authenticator.delegate = self
     }
@@ -29,9 +31,10 @@ public class NetworkManager {
     }
 
     public func publisher<Response>(for endpoint: Endpoint<Response>) -> AnyPublisher<Response, Swift.Error> {
-        return authenticator.validToken(withConfiguration: endpoint.configuration)
-            .map { token -> Endpoint<Response> in
+        return authenticator.validToken(withConfiguration: configuration)
+            .map { [self] token -> Endpoint<Response> in
                 var endpoint = endpoint
+                endpoint.domain = configuration.domain
                 endpoint.token = token
                 return endpoint
             }

--- a/Sources/Core/NetworkManager.swift
+++ b/Sources/Core/NetworkManager.swift
@@ -12,7 +12,7 @@ public protocol NetworkManagerDelegate: AnyObject {
     func networkManager(_ networkManager: NetworkManager, appUserForConfiguration configuration: Configuration) -> AppUser?
     func networkManager(_ networkManager: NetworkManager, appUserUpdated appUser: AppUser)
 
-    func networkManager(_ networkManager: NetworkManager, projectIdForConfiguration configuration: Configuration) -> String
+    func networkManager(_ networkManager: NetworkManager, projectIdForConfiguration configuration: Configuration) -> String?
 }
 
 public class NetworkManager {

--- a/Tests/Core/AuthenticatorTests.swift
+++ b/Tests/Core/AuthenticatorTests.swift
@@ -13,7 +13,7 @@ final class AuthenticatorTests: XCTestCase {
 
     var authenticator: Authenticator!
     var cancellables = Set<AnyCancellable>()
-    var configuration = Configuration(appId: "123", appSecret: "123-456-789", domain: .testing, projectId: "123")
+    var configuration = Configuration(appId: "123", appSecret: "123-456-789", domain: .testing)
     var urlSession: URLSession = .mockSession
 
     override func setUpWithError() throws {
@@ -90,7 +90,7 @@ extension AuthenticatorTests: AuthenticatorDelegate {
         appUser
     }
 
-    func authenticator(_ authenticator: Authenticator, projectIdForConfiguration configuration: Configuration) -> String {
+    func authenticator(_ authenticator: Authenticator, projectIdForConfiguration configuration: Configuration) -> String? {
         projectId
     }
 }

--- a/Tests/Core/EndpointTests.swift
+++ b/Tests/Core/EndpointTests.swift
@@ -16,7 +16,7 @@ final class EndpointTests: XCTestCase {
 
     let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
     func testDefaultInit() throws {
-        let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil), configuration: configuration) { _ in
+        let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil)) { _ in
             return Mock(name: "foobar")
         }
         XCTAssertEqual(endpoint.method, .get(nil))
@@ -27,33 +27,20 @@ final class EndpointTests: XCTestCase {
     }
 
     func testEnvironmentParameter() throws {
-        var configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
-        var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil), configuration: configuration) { _ in
+        var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil)) { _ in
             Mock(name: "foobar")
         }
         XCTAssertEqual(endpoint.domain, .production)
-
-        configuration = .init(appId: "1", appSecret: "2", domain: .staging)
-        endpoint = .init(path: "/apps/mock", method: .get(nil), configuration: configuration) { _ in
-            Mock(name: "foobar")
-        }
-        XCTAssertEqual(endpoint.domain, .staging)
-
-        configuration = .init(appId: "1", appSecret: "2", domain: .testing)
-        endpoint = .init(path: "/apps/mock", method: .get(nil), configuration: configuration) { _ in
-            Mock(name: "foobar")
-        }
-        XCTAssertEqual(endpoint.domain, .testing)
     }
 
     func testPathParameter() throws {
         let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
-        var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil), configuration: configuration) { _ in
+        var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil)) { _ in
             Mock(name: "foobar")
         }
         XCTAssertEqual(endpoint.path, "/apps/mock")
 
-        endpoint = .init(path: "/foobar/mock2", method: .get(nil), configuration: configuration) { _ in
+        endpoint = .init(path: "/foobar/mock2", method: .get(nil)) { _ in
             Mock(name: "foobar")
         }
         XCTAssertEqual(endpoint.path, "/foobar/mock2")
@@ -61,17 +48,17 @@ final class EndpointTests: XCTestCase {
 
     func testMethodParameter() throws {
         let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
-        var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil), configuration: configuration) { _ in
+        var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil)) { _ in
             Mock(name: "foobar")
         }
         XCTAssertEqual(endpoint.method, .get(nil))
 
-        endpoint = .init(path: "/apps/mock", method: .get([.init(name: "foobar", value: "1")]), configuration: configuration) { _ in
+        endpoint = .init(path: "/apps/mock", method: .get([.init(name: "foobar", value: "1")])) { _ in
             Mock(name: "foobar")
         }
         XCTAssertEqual(endpoint.method, .get([.init(name: "foobar", value: "1")]))
 
-        endpoint = .init(path: "/apps/mock", method: .head, configuration: configuration) { _ in
+        endpoint = .init(path: "/apps/mock", method: .head) { _ in
             Mock(name: "foobar")
         }
         XCTAssertEqual(endpoint.method, .head)
@@ -79,7 +66,7 @@ final class EndpointTests: XCTestCase {
 
     func testToken() throws {
         let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
-        var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil), configuration: configuration) { _ in
+        var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil)) { _ in
             Mock(name: "foobar")
         }
         XCTAssertNil(endpoint.token)
@@ -95,7 +82,7 @@ final class EndpointTests: XCTestCase {
         let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get([
             .init(name: "foobar", value: "1"),
             .init(name: "barfoo", value: "100")
-        ]), configuration: configuration) { _ in
+        ])) { _ in
             Mock(name: "foobar")
         }
         let urlRequest = try! endpoint.urlRequest()
@@ -110,7 +97,7 @@ final class EndpointTests: XCTestCase {
         var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get([
             .init(name: "foobar", value: "1"),
             .init(name: "barfoo", value: "100")
-        ]), configuration: configuration) { _ in
+        ])) { _ in
             Mock(name: "foobar")
         }
         endpoint.headerFields = ["Content-Type": "application/text"]
@@ -139,7 +126,7 @@ final class EndpointTests: XCTestCase {
         let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .post(jsonData, [
             .init(name: "foobar", value: "1"),
             .init(name: "barfoo", value: "100")
-        ]), configuration: configuration) { _ in
+        ])) { _ in
             Mock(name: "foobar")
         }
         let urlRequest = try! endpoint.urlRequest()
@@ -164,7 +151,7 @@ final class EndpointTests: XCTestCase {
         """
         let jsonData = Data(jsonString.utf8)
         let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
-        let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .put(jsonData), configuration: configuration) { _ in
+        let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .put(jsonData)) { _ in
             Mock(name: "foobar")
         }
         let urlRequest = try! endpoint.urlRequest()
@@ -189,7 +176,7 @@ final class EndpointTests: XCTestCase {
         """
         let jsonData = Data(jsonString.utf8)
         let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
-        let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .patch(jsonData), configuration: configuration) { _ in
+        let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .patch(jsonData)) { _ in
             Mock(name: "foobar")
         }
         let urlRequest = try! endpoint.urlRequest()
@@ -214,7 +201,7 @@ final class EndpointTests: XCTestCase {
         """
         let jsonData = Data(jsonString.utf8)
         let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
-        let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .delete(jsonData), configuration: configuration) { _ in
+        let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .delete(jsonData)) { _ in
             Mock(name: "foobar")
         }
         let urlRequest = try! endpoint.urlRequest()
@@ -226,7 +213,7 @@ final class EndpointTests: XCTestCase {
 
     func testHEADURLRequest() throws {
         let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
-        let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .head, configuration: configuration) { _ in
+        let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .head) { _ in
             Mock(name: "foobar")
         }
         let urlRequest = try! endpoint.urlRequest()

--- a/Tests/Core/EndpointTests.swift
+++ b/Tests/Core/EndpointTests.swift
@@ -27,14 +27,13 @@ final class EndpointTests: XCTestCase {
     }
 
     func testEnvironmentParameter() throws {
-        var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil)) { _ in
+        let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil)) { _ in
             Mock(name: "foobar")
         }
         XCTAssertEqual(endpoint.domain, .production)
     }
 
     func testPathParameter() throws {
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil)) { _ in
             Mock(name: "foobar")
         }
@@ -47,7 +46,6 @@ final class EndpointTests: XCTestCase {
     }
 
     func testMethodParameter() throws {
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil)) { _ in
             Mock(name: "foobar")
         }
@@ -65,7 +63,6 @@ final class EndpointTests: XCTestCase {
     }
 
     func testToken() throws {
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil)) { _ in
             Mock(name: "foobar")
         }
@@ -78,7 +75,6 @@ final class EndpointTests: XCTestCase {
     }
 
     func testGETURLRequestWithQueryItems() throws {
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get([
             .init(name: "foobar", value: "1"),
             .init(name: "barfoo", value: "100")
@@ -93,7 +89,6 @@ final class EndpointTests: XCTestCase {
     }
 
     func testGETURLRequestWithQueryItemsOverwriteHeaderfields() throws {
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get([
             .init(name: "foobar", value: "1"),
             .init(name: "barfoo", value: "100")
@@ -122,7 +117,6 @@ final class EndpointTests: XCTestCase {
         ]
         """
         let jsonData = Data(jsonString.utf8)
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .post(jsonData, [
             .init(name: "foobar", value: "1"),
             .init(name: "barfoo", value: "100")
@@ -150,7 +144,6 @@ final class EndpointTests: XCTestCase {
         ]
         """
         let jsonData = Data(jsonString.utf8)
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .put(jsonData)) { _ in
             Mock(name: "foobar")
         }
@@ -175,7 +168,6 @@ final class EndpointTests: XCTestCase {
         ]
         """
         let jsonData = Data(jsonString.utf8)
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .patch(jsonData)) { _ in
             Mock(name: "foobar")
         }
@@ -200,7 +192,6 @@ final class EndpointTests: XCTestCase {
         ]
         """
         let jsonData = Data(jsonString.utf8)
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .delete(jsonData)) { _ in
             Mock(name: "foobar")
         }
@@ -212,7 +203,6 @@ final class EndpointTests: XCTestCase {
     }
 
     func testHEADURLRequest() throws {
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .head) { _ in
             Mock(name: "foobar")
         }

--- a/Tests/Core/EndpointTests.swift
+++ b/Tests/Core/EndpointTests.swift
@@ -14,7 +14,7 @@ struct Mock: Decodable {
 
 final class EndpointTests: XCTestCase {
 
-    let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production, projectId: "1")
+    let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
     func testDefaultInit() throws {
         let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil), configuration: configuration) { _ in
             return Mock(name: "foobar")
@@ -27,19 +27,19 @@ final class EndpointTests: XCTestCase {
     }
 
     func testEnvironmentParameter() throws {
-        var configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production, projectId: "1")
+        var configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil), configuration: configuration) { _ in
             Mock(name: "foobar")
         }
         XCTAssertEqual(endpoint.domain, .production)
 
-        configuration = .init(appId: "1", appSecret: "2", domain: .staging, projectId: "1")
+        configuration = .init(appId: "1", appSecret: "2", domain: .staging)
         endpoint = .init(path: "/apps/mock", method: .get(nil), configuration: configuration) { _ in
             Mock(name: "foobar")
         }
         XCTAssertEqual(endpoint.domain, .staging)
 
-        configuration = .init(appId: "1", appSecret: "2", domain: .testing, projectId: "1")
+        configuration = .init(appId: "1", appSecret: "2", domain: .testing)
         endpoint = .init(path: "/apps/mock", method: .get(nil), configuration: configuration) { _ in
             Mock(name: "foobar")
         }
@@ -47,7 +47,7 @@ final class EndpointTests: XCTestCase {
     }
 
     func testPathParameter() throws {
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production, projectId: "1")
+        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil), configuration: configuration) { _ in
             Mock(name: "foobar")
         }
@@ -60,7 +60,7 @@ final class EndpointTests: XCTestCase {
     }
 
     func testMethodParameter() throws {
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production, projectId: "1")
+        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil), configuration: configuration) { _ in
             Mock(name: "foobar")
         }
@@ -78,7 +78,7 @@ final class EndpointTests: XCTestCase {
     }
 
     func testToken() throws {
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production, projectId: "1")
+        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get(nil), configuration: configuration) { _ in
             Mock(name: "foobar")
         }
@@ -91,7 +91,7 @@ final class EndpointTests: XCTestCase {
     }
 
     func testGETURLRequestWithQueryItems() throws {
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production, projectId: "1")
+        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get([
             .init(name: "foobar", value: "1"),
             .init(name: "barfoo", value: "100")
@@ -106,7 +106,7 @@ final class EndpointTests: XCTestCase {
     }
 
     func testGETURLRequestWithQueryItemsOverwriteHeaderfields() throws {
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production, projectId: "1")
+        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         var endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .get([
             .init(name: "foobar", value: "1"),
             .init(name: "barfoo", value: "100")
@@ -135,7 +135,7 @@ final class EndpointTests: XCTestCase {
         ]
         """
         let jsonData = Data(jsonString.utf8)
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production, projectId: "1")
+        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .post(jsonData, [
             .init(name: "foobar", value: "1"),
             .init(name: "barfoo", value: "100")
@@ -163,7 +163,7 @@ final class EndpointTests: XCTestCase {
         ]
         """
         let jsonData = Data(jsonString.utf8)
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production, projectId: "1")
+        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .put(jsonData), configuration: configuration) { _ in
             Mock(name: "foobar")
         }
@@ -188,7 +188,7 @@ final class EndpointTests: XCTestCase {
         ]
         """
         let jsonData = Data(jsonString.utf8)
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production, projectId: "1")
+        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .patch(jsonData), configuration: configuration) { _ in
             Mock(name: "foobar")
         }
@@ -213,7 +213,7 @@ final class EndpointTests: XCTestCase {
         ]
         """
         let jsonData = Data(jsonString.utf8)
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production, projectId: "1")
+        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .delete(jsonData), configuration: configuration) { _ in
             Mock(name: "foobar")
         }
@@ -225,7 +225,7 @@ final class EndpointTests: XCTestCase {
     }
 
     func testHEADURLRequest() throws {
-        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production, projectId: "1")
+        let configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
         let endpoint: Endpoint<Mock> = .init(path: "/apps/mock", method: .head, configuration: configuration) { _ in
             Mock(name: "foobar")
         }

--- a/Tests/Core/Endpoints/AppUserEndpointTests.swift
+++ b/Tests/Core/Endpoints/AppUserEndpointTests.swift
@@ -13,8 +13,7 @@ final class AppUserEndpointTests: XCTestCase {
     var configuration: Configuration = .init(appId: "1", appSecret: "ABCDEFGHIJKLMNOP", domain: .production)
 
     func testPostWithoutProject() throws {
-        let endpoint = Endpoints.AppUser.post(configuration: configuration)
-        XCTAssertEqual(endpoint.configuration, configuration)
+        let endpoint = Endpoints.AppUser.post(appId: configuration.appId, appSecret: configuration.appSecret)
         XCTAssertEqual(endpoint.domain, .production)
         XCTAssertEqual(endpoint.method.value, "POST")
         XCTAssertEqual(endpoint.path, "/apps/1/users")
@@ -27,8 +26,7 @@ final class AppUserEndpointTests: XCTestCase {
     }
 
     func testPostWithProject() throws {
-        let endpoint = Endpoints.AppUser.post(configuration: configuration, projectId: "2")
-        XCTAssertEqual(endpoint.configuration, configuration)
+        let endpoint = Endpoints.AppUser.post(appId: configuration.appId, appSecret: configuration.appSecret, projectId: "2")
         XCTAssertEqual(endpoint.domain, .production)
         XCTAssertEqual(endpoint.method.value, "POST")
         XCTAssertEqual(endpoint.path, "/apps/1/users")

--- a/Tests/Core/Endpoints/AppUserEndpointTests.swift
+++ b/Tests/Core/Endpoints/AppUserEndpointTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 final class AppUserEndpointTests: XCTestCase {
 
-    var configuration: Configuration = .init(appId: "1", appSecret: "ABCDEFGHIJKLMNOP", domain: .production, projectId: "1")
+    var configuration: Configuration = .init(appId: "1", appSecret: "ABCDEFGHIJKLMNOP", domain: .production)
 
     func testPostWithoutProject() throws {
         let endpoint = Endpoints.AppUser.post(configuration: configuration)

--- a/Tests/Core/Endpoints/PhoneEndpointTests.swift
+++ b/Tests/Core/Endpoints/PhoneEndpointTests.swift
@@ -21,7 +21,7 @@ final class PhoneEndpointTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    var configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production, projectId: "1")
+    var configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
     var appUser: AppUser = .init(id: "555", secret: "123-456-789")
 
     func testAuth() throws {

--- a/Tests/Core/Endpoints/PhoneEndpointTests.swift
+++ b/Tests/Core/Endpoints/PhoneEndpointTests.swift
@@ -25,8 +25,7 @@ final class PhoneEndpointTests: XCTestCase {
     var appUser: AppUser = .init(id: "555", secret: "123-456-789")
 
     func testAuth() throws {
-        let endpoint = Endpoints.Phone.auth(configuration: configuration, phoneNumber: phoneNumber)
-        XCTAssertEqual(endpoint.configuration, configuration)
+        let endpoint = Endpoints.Phone.auth(appId: configuration.appId, phoneNumber: phoneNumber)
         XCTAssertEqual(endpoint.domain, .production)
         XCTAssertEqual(endpoint.method.value, "POST")
         XCTAssertEqual(endpoint.path, "/1/verification/sms")
@@ -42,8 +41,7 @@ final class PhoneEndpointTests: XCTestCase {
     }
 
     func testLogin() throws {
-        let endpoint = Endpoints.Phone.login(configuration: configuration, phoneNumber: phoneNumber, OTP: otp)
-        XCTAssertEqual(endpoint.configuration, configuration)
+        let endpoint = Endpoints.Phone.login(appId: configuration.appId, phoneNumber: phoneNumber, OTP: otp)
         XCTAssertEqual(endpoint.domain, .production)
         XCTAssertEqual(endpoint.method.value, "POST")
         XCTAssertEqual(endpoint.path, "/1/verification/sms/otp")
@@ -60,8 +58,7 @@ final class PhoneEndpointTests: XCTestCase {
     }
 
     func testDelete() throws {
-        let endpoint = Endpoints.Phone.delete(configuration: configuration, phoneNumber: phoneNumber)
-        XCTAssertEqual(endpoint.configuration, configuration)
+        let endpoint = Endpoints.Phone.delete(appId: configuration.appId, phoneNumber: phoneNumber)
         XCTAssertEqual(endpoint.domain, .production)
         XCTAssertEqual(endpoint.method.value, "POST")
         XCTAssertEqual(endpoint.path, "/1/verification/sms/delete")

--- a/Tests/Core/Endpoints/TokenEndpointTests.swift
+++ b/Tests/Core/Endpoints/TokenEndpointTests.swift
@@ -22,8 +22,7 @@ final class TokenEndpointTests: XCTestCase {
     var appUser: AppUser = .init(id: "555", secret: "123-456-789")
 
     func testGet() throws {
-        let endpoint = Endpoints.Token.get(configuration: configuration, appUser: appUser, projectId: "2")
-        XCTAssertEqual(endpoint.configuration, configuration)
+        let endpoint = Endpoints.Token.get(appId: configuration.appId, appSecret: configuration.appSecret, appUser: appUser, projectId: "2")
         XCTAssertEqual(endpoint.domain, .production)
         XCTAssertEqual(endpoint.method.value, "GET")
         XCTAssertEqual(endpoint.path, "/tokens")

--- a/Tests/Core/Endpoints/TokenEndpointTests.swift
+++ b/Tests/Core/Endpoints/TokenEndpointTests.swift
@@ -18,7 +18,7 @@ final class TokenEndpointTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    var configuration: Configuration = .init(appId: "1", appSecret: "ABCDEFGHIJKLMNOP", domain: .production, projectId: "1")
+    var configuration: Configuration = .init(appId: "1", appSecret: "ABCDEFGHIJKLMNOP", domain: .production)
     var appUser: AppUser = .init(id: "555", secret: "123-456-789")
 
     func testGet() throws {

--- a/Tests/Core/Endpoints/UserEndpointTests.swift
+++ b/Tests/Core/Endpoints/UserEndpointTests.swift
@@ -18,11 +18,10 @@ final class UserEndpointTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    var configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
+//    var configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
 
     func testMe() throws {
-        let endpoint = Endpoints.User.me(configuration: configuration)
-        XCTAssertEqual(endpoint.configuration, configuration)
+        let endpoint = Endpoints.User.me()
         XCTAssertEqual(endpoint.domain, .production)
         XCTAssertEqual(endpoint.method.value, "GET")
         XCTAssertEqual(endpoint.path, "/apps/users/me")
@@ -34,8 +33,7 @@ final class UserEndpointTests: XCTestCase {
 
     func testUpdate() throws {
         let details = User.Details(firstName: "Foo", lastName: "Bar", email: "foo@bar.com")
-        let endpoint = Endpoints.User.update(configuration: configuration, details: details)
-        XCTAssertEqual(endpoint.configuration, configuration)
+        let endpoint = Endpoints.User.update(details: details)
         XCTAssertEqual(endpoint.domain, .production)
         XCTAssertEqual(endpoint.method.value, "PUT")
         XCTAssertEqual(endpoint.path, "/apps/users/me/details")
@@ -53,8 +51,7 @@ final class UserEndpointTests: XCTestCase {
     }
 
     func testDelete() throws {
-        let endpoint = Endpoints.User.erase(configuration: configuration)
-        XCTAssertEqual(endpoint.configuration, configuration)
+        let endpoint = Endpoints.User.erase()
         XCTAssertEqual(endpoint.domain, .production)
         XCTAssertEqual(endpoint.method.value, "POST")
         XCTAssertEqual(endpoint.path, "/apps/users/me/erase")

--- a/Tests/Core/Endpoints/UserEndpointTests.swift
+++ b/Tests/Core/Endpoints/UserEndpointTests.swift
@@ -18,7 +18,7 @@ final class UserEndpointTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    var configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production, projectId: "1")
+    var configuration: Configuration = .init(appId: "1", appSecret: "2", domain: .production)
 
     func testMe() throws {
         let endpoint = Endpoints.User.me(configuration: configuration)

--- a/Tests/Core/NetworkManagerTests.swift
+++ b/Tests/Core/NetworkManagerTests.swift
@@ -131,7 +131,7 @@ extension NetworkManagerTests: NetworkManagerDelegate {
         appUser
     }
 
-    func networkManager(_ networkManager: NetworkManager, projectIdForConfiguration configuration: Configuration) -> String {
+    func networkManager(_ networkManager: NetworkManager, projectIdForConfiguration configuration: Configuration) -> String? {
         "123"
     }
 }

--- a/Tests/Core/NetworkManagerTests.swift
+++ b/Tests/Core/NetworkManagerTests.swift
@@ -19,7 +19,7 @@ final class NetworkManagerTests: XCTestCase {
 
     override func setUpWithError() throws {
         cancellables = Set<AnyCancellable>()
-        networkManager = NetworkManager(urlSession: .mockSession)
+        networkManager = NetworkManager(configuration: configuration, urlSession: .mockSession)
         networkManager.delegate = self
 
         MockURLProtocol.error = nil
@@ -78,7 +78,7 @@ final class NetworkManagerTests: XCTestCase {
             return (response, Data())
         }
 
-        let endpoint = Endpoints.AppUser.post(configuration: configuration)
+        let endpoint = Endpoints.AppUser.post(appId: configuration.appId, appSecret: configuration.appSecret)
 
         let expectation = expectation(description: "register")
         networkManager.publisher(for: endpoint)
@@ -98,7 +98,7 @@ final class NetworkManagerTests: XCTestCase {
     }
 
     func testEndpoint() throws {
-        let endpoint = Endpoints.Phone.auth(configuration: configuration, phoneNumber: "+4915119695415")
+        let endpoint = Endpoints.Phone.auth(appId: configuration.appId, phoneNumber: "+4915119695415")
 
         let expectation = expectation(description: "auth")
         networkManager.publisher(for: endpoint)

--- a/Tests/Core/URLSessionEndpointTests.swift
+++ b/Tests/Core/URLSessionEndpointTests.swift
@@ -12,7 +12,7 @@ import Combine
 final class URLSessionEndpointTests: XCTestCase {
 
     let resourceData = try! loadResource(inBundle: .module, filename: "UsersResponse", withExtension: "json")
-    let endpointUsers: Endpoint<UsersResponse> = Endpoints.AppUser.post(configuration: .init(appId: "123-456-789", appSecret: "1", domain: .production, projectId: "123-456-789"))
+    let endpointUsers: Endpoint<UsersResponse> = Endpoints.AppUser.post(configuration: .init(appId: "123-456-789", appSecret: "1", domain: .production))
     var cancellables = Set<AnyCancellable>()
 
     // MARK: - Decodable

--- a/Tests/Core/URLSessionEndpointTests.swift
+++ b/Tests/Core/URLSessionEndpointTests.swift
@@ -12,7 +12,7 @@ import Combine
 final class URLSessionEndpointTests: XCTestCase {
 
     let resourceData = try! loadResource(inBundle: .module, filename: "UsersResponse", withExtension: "json")
-    let endpointUsers: Endpoint<UsersResponse> = Endpoints.AppUser.post(configuration: .init(appId: "123-456-789", appSecret: "1", domain: .production))
+    let endpointUsers: Endpoint<UsersResponse> = Endpoints.AppUser.post(appId: "123-456-789", appSecret: "1")
     var cancellables = Set<AnyCancellable>()
 
     // MARK: - Decodable


### PR DESCRIPTION
* Remove `ProjectId` from `Configuration` it's dynamic just like `appUserId`
* Remove `Configuration` from `Endpoints`
* Add `Configuration` to `NetworkManager`
* adds async/await method